### PR TITLE
fix: container install asdf, nodejs, pnpm, just

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,3 +8,23 @@ RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ca
     && chmod +x ~/.cargo/bin/dprint
 
 RUN rustup toolchain install nightly --profile minimal --component rustfmt
+
+# Configurator build deps
+USER root
+RUN apt-get update \
+    && apt-get install -y dirmngr gpg gawk
+
+USER esp
+RUN git clone https://github.com/asdf-vm/asdf.git $HOME/.asdf --branch v0.14.0 \
+    && echo ' . "$HOME/.asdf/asdf.sh"' >> $HOME/.bashrc 
+RUN bash -i -c "asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git \
+    && asdf install nodejs latest \
+    && asdf global nodejs latest"
+
+RUN bash -i -c "corepack enable pnpm \
+    && env ENV=$HOME/.bashrc SHELL=$(which bash) corepack pnpm setup \
+    && echo \"alias pnpm=\\\"corepack pnpm\\\"\" >> $HOME/.bashrc"
+
+RUN bash -i -c "pnpm add -g just-install"
+
+USER esp


### PR DESCRIPTION
[devpod.sh](https://devpod.sh/) installs the requisite utils automatically, but other environments need the additional setup to build ootb.