### PR TITLE
Update Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,15 +131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,7 +152,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.36.7",
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
@@ -213,18 +204,18 @@ checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
 name = "bitfield"
-version = "0.19.1"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db1bcd90f88eabbf0cadbfb87a45bceeaebcd3b4bc9e43da379cd2ef0162590d"
+checksum = "21ba6517c6b0f2bf08be60e187ab64b038438f22dd755614d8fe4d4098c46419"
 dependencies = [
  "bitfield-macros",
 ]
 
 [[package]]
 name = "bitfield-macros"
-version = "0.19.1"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3787a07661997bfc05dd3431e379c0188573f78857080cf682e1393ab8e4d64c"
+checksum = "f48d6ace212fdf1b45fd6b566bb40808415344642b76c3224c07c8df9da81e97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -263,16 +254,26 @@ dependencies = [
 
 [[package]]
 name = "bt-hci"
-version = "0.3.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7f7c19df9648c1da4f5356c4256533e38bd65633b6a41654922475a1c6d777"
+checksum = "bb938a3b4c5cc6c2409275bad789c0346a0495fa071a0acc5d72b9bd3175a2f7"
 dependencies = [
+ "btuuid",
  "defmt 1.0.1",
- "embassy-sync 0.7.0",
+ "embassy-sync 0.7.2",
  "embedded-io 0.6.1",
  "embedded-io-async 0.6.1",
  "futures-intrusive",
- "heapless",
+ "heapless 0.9.2",
+]
+
+[[package]]
+name = "btuuid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0acfef8a77a02866e04f7e2ad3f4c7b32d575696c49c4bbad742b4aecb8e4a3"
+dependencies = [
+ "defmt 0.3.100",
 ]
 
 [[package]]
@@ -289,9 +290,9 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.1"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -362,9 +363,9 @@ checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
 
 [[package]]
 name = "const_format"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
 dependencies = [
  "const_format_proc_macros",
 ]
@@ -423,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
 dependencies = [
  "crc-catalog",
 ]
@@ -551,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "defmt-rtt"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2cac3b8a5644a9e02b75085ebad3b6deafdbdbdec04bb25086523828aa4dfd1"
+checksum = "93d5a25c99d89c40f5676bec8cefe0614f17f0f40e916f98e345dae941807f9e"
 dependencies = [
  "critical-section",
  "defmt 1.0.1",
@@ -561,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "delegate"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6178a82cf56c836a3ba61a7935cdb1c49bfaa6fa4327cd5bf554a503087de26b"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -628,8 +629,8 @@ dependencies = [
  "edge-nal",
  "edge-raw",
  "embassy-futures",
- "embassy-time",
- "heapless",
+ "embassy-time 0.4.0",
+ "heapless 0.8.0",
  "log",
  "num_enum",
  "rand_core 0.6.4",
@@ -641,7 +642,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac19c3edcdad839c71cb919cd09a632d9915d630760b37f0b74290188c08f248"
 dependencies = [
- "embassy-time",
+ "embassy-time 0.4.0",
  "embedded-io-async 0.6.1",
 ]
 
@@ -659,31 +660,13 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embassy-embedded-hal"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c62a3bf127e03832fb97d8b01a058775e617653bc89e2a12c256485a7fb54c1"
-dependencies = [
- "embassy-embedded-hal 0.4.0",
- "embassy-futures",
- "embassy-sync 0.6.2",
- "embassy-time",
- "embedded-hal 0.2.7",
- "embedded-hal 1.0.0",
- "embedded-hal-async",
- "embedded-storage",
- "embedded-storage-async",
- "nb 1.1.0",
-]
-
-[[package]]
-name = "embassy-embedded-hal"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1611b7a7ab5d1fbed84c338df26d56fd9bded58006ebb029075112ed2c5e039"
+checksum = "554e3e840696f54b4c9afcf28a0f24da431c927f4151040020416e7393d6d0d8"
 dependencies = [
  "embassy-futures",
  "embassy-hal-internal",
- "embassy-sync 0.7.0",
+ "embassy-sync 0.7.2",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
@@ -694,23 +677,24 @@ dependencies = [
 
 [[package]]
 name = "embassy-executor"
-version = "0.7.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90327bcc66333a507f89ecc4e2d911b265c45f5c9bc241f98eee076752d35ac6"
+checksum = "06070468370195e0e86f241c8e5004356d696590a678d47d6676795b2e439c6b"
 dependencies = [
  "cortex-m",
  "critical-section",
  "document-features",
  "embassy-executor-macros",
+ "embassy-executor-timer-queue",
  "js-sys",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "embassy-executor-macros"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3577b1e9446f61381179a330fc5324b01d511624c55f25e3c66c9e3c626dbecf"
+checksum = "dfdddc3a04226828316bf31393b6903ee162238576b1584ee2669af215d55472"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -719,12 +703,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "embassy-futures"
-version = "0.1.1"
+name = "embassy-executor-timer-queue"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f878075b9794c1e4ac788c95b728f26aa6366d32eeb10c7051389f898f7d067"
+checksum = "2fc328bf943af66b80b98755db9106bf7e7471b0cf47dc8559cd9a6be504cc9c"
+
+[[package]]
+name = "embassy-futures"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc2d050bdc5c21e0862a89256ed8029ae6c290a93aecefc73084b3002cdebb01"
 dependencies = [
- "defmt 0.3.100",
+ "defmt 1.0.1",
 ]
 
 [[package]]
@@ -741,18 +731,18 @@ dependencies = [
 
 [[package]]
 name = "embassy-net"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940c4b9fe5c1375b09a0c6722c0100d6b2ed46a717a34f632f26e8d7327c4383"
+checksum = "0558a231a47e7d4a06a28b5278c92e860f1200f24821d2f365a2f40fe3f3c7b2"
 dependencies = [
- "defmt 0.3.100",
+ "defmt 1.0.1",
  "document-features",
  "embassy-net-driver",
- "embassy-sync 0.6.2",
- "embassy-time",
+ "embassy-sync 0.7.2",
+ "embassy-time 0.5.0",
  "embedded-io-async 0.6.1",
  "embedded-nal-async",
- "heapless",
+ "heapless 0.8.0",
  "log",
  "managed",
  "smoltcp",
@@ -769,25 +759,24 @@ dependencies = [
 
 [[package]]
 name = "embassy-rp"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d298ea0ae8797fbbc835d7ef321b1762916879b9df49695826f54d31c487f5de"
+checksum = "af8d5ac11a8bc209d359ad98bb10a10f786471dd474790f3a4f991c77ae94f6f"
 dependencies = [
- "atomic-polyfill",
  "cfg-if",
  "cortex-m",
  "cortex-m-rt",
  "critical-section",
  "defmt 1.0.1",
  "document-features",
- "embassy-embedded-hal 0.3.2",
+ "embassy-embedded-hal",
  "embassy-futures",
  "embassy-hal-internal",
- "embassy-sync 0.7.0",
- "embassy-time",
+ "embassy-sync 0.7.2",
+ "embassy-time 0.5.0",
  "embassy-time-driver",
  "embassy-time-queue-utils",
- "embassy-usb-driver 0.2.0",
+ "embassy-usb-driver",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
@@ -815,25 +804,25 @@ checksum = "8d2c8cdff05a7a51ba0087489ea44b0b1d97a296ca6b1d6d1a33ea7423d34049"
 dependencies = [
  "cfg-if",
  "critical-section",
- "defmt 0.3.100",
  "embedded-io-async 0.6.1",
  "futures-sink",
  "futures-util",
- "heapless",
+ "heapless 0.8.0",
 ]
 
 [[package]]
 name = "embassy-sync"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef1a8a1ea892f9b656de0295532ac5d8067e9830d49ec75076291fd6066b136"
+checksum = "73974a3edbd0bd286759b3d483540f0ebef705919a5f56f4fc7709066f71689b"
 dependencies = [
  "cfg-if",
  "critical-section",
+ "defmt 1.0.1",
  "embedded-io-async 0.6.1",
+ "futures-core",
  "futures-sink",
- "futures-util",
- "heapless",
+ "heapless 0.8.0",
 ]
 
 [[package]]
@@ -847,11 +836,28 @@ dependencies = [
  "defmt 0.3.100",
  "document-features",
  "embassy-time-driver",
- "embassy-time-queue-utils",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "futures-util",
+]
+
+[[package]]
+name = "embassy-time"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa65b9284d974dad7a23bb72835c4ec85c0b540d86af7fc4098c88cff51d65"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "defmt 1.0.1",
+ "document-features",
+ "embassy-time-driver",
+ "embassy-time-queue-utils",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "futures-core",
  "js-sys",
  "wasm-bindgen",
  "wasm-timer",
@@ -859,30 +865,21 @@ dependencies = [
 
 [[package]]
 name = "embassy-time-driver"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d45f5d833b6d98bd2aab0c2de70b18bfaa10faf661a1578fd8e5dfb15eb7eba"
+checksum = "a0a244c7dc22c8d0289379c8d8830cae06bb93d8f990194d0de5efb3b5ae7ba6"
 dependencies = [
  "document-features",
 ]
 
 [[package]]
 name = "embassy-time-queue-utils"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc55c748d16908a65b166d09ce976575fb8852cf60ccd06174092b41064d8f83"
+checksum = "80e2ee86063bd028a420a5fb5898c18c87a8898026da1d4c852af2c443d0a454"
 dependencies = [
- "embassy-executor",
- "heapless",
-]
-
-[[package]]
-name = "embassy-usb-driver"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "340c5ce591ef58c6449e43f51d2c53efe1bf0bb6a40cbf80afa0d259c7d52c76"
-dependencies = [
- "embedded-io-async 0.6.1",
+ "embassy-executor-timer-queue",
+ "heapless 0.8.0",
 ]
 
 [[package]]
@@ -897,13 +894,13 @@ dependencies = [
 
 [[package]]
 name = "embassy-usb-synopsys-otg"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08e753b23799329780c7ac434264026d0422044d6649ed70a73441b14a6436d7"
+checksum = "288751f8eaa44a5cf2613f13cee0ca8e06e6638cb96e897e6834702c79084b23"
 dependencies = [
  "critical-section",
- "embassy-sync 0.6.2",
- "embassy-usb-driver 0.1.1",
+ "embassy-sync 0.7.2",
+ "embassy-usb-driver",
 ]
 
 [[package]]
@@ -967,9 +964,6 @@ name = "embedded-hal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
-dependencies = [
- "defmt 0.3.100",
-]
 
 [[package]]
 name = "embedded-hal-async"
@@ -1084,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "embedded-text"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005680edc0d075af5e02d5788ca291737bd9aba7fc404ae031cc9dfa715e5f7d"
+checksum = "6cf5c72c52db2f7dbe4a9c1ed81cd21301e8d66311b194fa41c04fb4f71843ba"
 dependencies = [
  "az",
  "embedded-graphics",
@@ -1153,52 +1147,77 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "esp-alloc"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e95f1de57ce5a6600368f3d3c931b0dfe00501661e96f5ab83bc5cdee031784"
+checksum = "641e43d6a60244429117ef2fa7a47182120c7561336ea01f6fb08d634f46bae1"
 dependencies = [
  "allocator-api2",
  "cfg-if",
- "critical-section",
+ "defmt 1.0.1",
  "document-features",
  "enumset",
+ "esp-config",
+ "esp-sync",
  "linked_list_allocator",
+ "rlsf",
 ]
 
 [[package]]
 name = "esp-backtrace"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f270a29a3c4e492399b13e157b10151a7616cba69c4d554076ea93ed1bd2916"
+checksum = "3318413fb566c7227387f67736cf70cd74d80a11f2bb31c7b95a9eb48d079669"
 dependencies = [
  "cfg-if",
  "defmt 1.0.1",
+ "document-features",
  "esp-config",
+ "esp-metadata-generated",
  "esp-println",
- "heapless",
+ "heapless 0.9.2",
+ "riscv",
  "semihosting",
+ "xtensa-lx",
+]
+
+[[package]]
+name = "esp-bootloader-esp-idf"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a56964ab5479ac20c9cf76fa3b0d3f2233b20b5d8554e81ef5d65f63c20567"
+dependencies = [
+ "cfg-if",
+ "defmt 1.0.1",
+ "document-features",
+ "embedded-storage",
+ "esp-config",
+ "esp-hal-procmacros",
+ "esp-metadata-generated",
+ "esp-rom-sys",
+ "jiff",
+ "strum",
 ]
 
 [[package]]
 name = "esp-config"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd4a8db4b72794637a25944bc8d361c3cc271d4f03987ce8741312b6b61529c"
+checksum = "102871054f8dd98202177b9890cb4b71d0c6fe1f1413b7a379a8e0841fc2473c"
 dependencies = [
  "document-features",
  "esp-metadata-generated",
- "evalexpr",
  "serde",
  "serde_yaml",
+ "somni-expr",
 ]
 
 [[package]]
 name = "esp-hal"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3887eda2917deef3d99e7a5c324f9190714e99055361ad36890dffd0a995b49"
+checksum = "54786287c0a61ca0f78cb0c338a39427551d1be229103b4444591796c579e093"
 dependencies = [
- "bitfield 0.19.1",
+ "bitfield 0.19.4",
  "bitflags 2.9.1",
  "bytemuck",
  "cfg-if",
@@ -1207,22 +1226,25 @@ dependencies = [
  "delegate",
  "digest",
  "document-features",
- "embassy-embedded-hal 0.3.2",
+ "embassy-embedded-hal",
  "embassy-futures",
- "embassy-sync 0.6.2",
- "embassy-usb-driver 0.1.1",
+ "embassy-sync 0.7.2",
+ "embassy-usb-driver",
  "embassy-usb-synopsys-otg",
  "embedded-can",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-io 0.6.1",
+ "embedded-io 0.7.1",
  "embedded-io-async 0.6.1",
+ "embedded-io-async 0.7.0",
  "enumset",
  "esp-config",
  "esp-hal-procmacros",
  "esp-metadata-generated",
  "esp-riscv-rt",
  "esp-rom-sys",
+ "esp-sync",
  "esp-synopsys-usb-otg",
  "esp32",
  "esp32c2",
@@ -1239,7 +1261,6 @@ dependencies = [
  "rand_core 0.6.4",
  "rand_core 0.9.3",
  "riscv",
- "serde",
  "strum",
  "ufmt-write",
  "xtensa-lx",
@@ -1247,36 +1268,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "esp-hal-embassy"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d000d94064c485f86adc6b02b541e2f072e03321b4f03d4303b7ff3062c7e692"
-dependencies = [
- "cfg-if",
- "critical-section",
- "document-features",
- "embassy-executor",
- "embassy-sync 0.6.2",
- "embassy-time",
- "embassy-time-driver",
- "embassy-time-queue-utils",
- "esp-config",
- "esp-hal",
- "esp-hal-procmacros",
- "esp-metadata-generated",
- "portable-atomic",
- "static_cell",
-]
-
-[[package]]
 name = "esp-hal-procmacros"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbece384edaf0d1eabfa45afa96d910634d4158638ef983b2d419a8dec832246"
+checksum = "3e025a7a7a0affdb4ff913b5c4494aef96ee03d085bf83c27453ae3a71d50da6"
 dependencies = [
  "document-features",
- "litrs",
- "object",
+ "object 0.37.3",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -1285,56 +1283,94 @@ dependencies = [
 ]
 
 [[package]]
-name = "esp-metadata"
-version = "0.8.0"
+name = "esp-metadata-generated"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6fbc1d166be84c0750f121e95c8989ddebd7e7bdd86af3594a6cfb34f039650"
-dependencies = [
- "anyhow",
- "basic-toml",
- "indexmap",
- "proc-macro2",
- "quote",
- "serde",
- "strum",
-]
+checksum = "9a93e39c8ad8d390d248dc7b9f4b59a873f313bf535218b8e2351356972399e3"
 
 [[package]]
-name = "esp-metadata-generated"
-version = "0.1.0"
+name = "esp-phy"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189d36b8c8a752bdebec67fd02a15ebb1432feea345553749bca7ce2393cc795"
+checksum = "6b1facf348e1e251517278fc0f5dc134e95e518251f5796cfbb532ca226a29bf"
 dependencies = [
- "esp-metadata",
+ "cfg-if",
+ "defmt 1.0.1",
+ "document-features",
+ "esp-config",
+ "esp-hal",
+ "esp-metadata-generated",
+ "esp-sync",
+ "esp-wifi-sys",
 ]
 
 [[package]]
 name = "esp-println"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7e3ab41e96093d7fd307e93bfc88bd646a8ff23036ebf809e116b18869f719"
+checksum = "5a30e6c9fbcc01c348d46706fef8131c7775ab84c254a3cd65d0cd3f6414d592"
 dependencies = [
  "document-features",
  "esp-metadata-generated",
+ "esp-sync",
  "log",
 ]
 
 [[package]]
-name = "esp-riscv-rt"
-version = "0.12.0"
+name = "esp-radio"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a00370dfcb0ccc01c6b2540076379c6efd6890a27f584de217c38e3239e19d5"
+checksum = "684c4de2f8907b73c9b891fbda65286a86d34fced4b856f36a7896c211f2f265"
 dependencies = [
+ "allocator-api2",
+ "bt-hci",
+ "cfg-if",
+ "defmt 1.0.1",
+ "document-features",
+ "embassy-net-driver",
+ "enumset",
+ "esp-alloc",
+ "esp-config",
+ "esp-hal",
+ "esp-hal-procmacros",
+ "esp-metadata-generated",
+ "esp-phy",
+ "esp-radio-rtos-driver",
+ "esp-sync",
+ "esp-wifi-sys",
+ "heapless 0.9.2",
+ "instability",
+ "num-derive",
+ "num-traits",
+ "portable-atomic",
+ "portable_atomic_enum",
+ "smoltcp",
+ "xtensa-lx-rt",
+]
+
+[[package]]
+name = "esp-radio-rtos-driver"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "543bc31d1851afd062357e7810c1a9633f282fd3993583499a841ab497cbca6c"
+
+[[package]]
+name = "esp-riscv-rt"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502744a5b1e7268d27fd2a4e56ad45efe42ead517d6c517a6961540de949b0ee"
+dependencies = [
+ "defmt 1.0.1",
  "document-features",
  "riscv",
- "riscv-rt-macros",
+ "riscv-rt",
 ]
 
 [[package]]
 name = "esp-rom-sys"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "646aca2b30503b6c6f34250255fbd5887fd0c4104ea90802c1fea34f3035e7d6"
+checksum = "cd66cccc6dd2d13e9f33668a57717ab14a6d217180ec112e6be533de93e7ecbf"
 dependencies = [
  "cfg-if",
  "document-features",
@@ -1342,15 +1378,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "esp-storage"
-version = "0.7.0"
+name = "esp-rtos"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f276ad8a3bdc6b47cd92a3e91013f2e42dce9b3fc5023392063387a1ce2ed69a"
+checksum = "162ec711c8d06e79c67b75d01595539e86b0aac209643af98ca87a12250428b3"
 dependencies = [
- "critical-section",
+ "allocator-api2",
+ "cfg-if",
+ "defmt 1.0.1",
+ "document-features",
+ "embassy-executor",
+ "embassy-sync 0.7.2",
+ "embassy-time-driver",
+ "embassy-time-queue-utils",
+ "esp-config",
+ "esp-hal",
+ "esp-hal-procmacros",
+ "esp-metadata-generated",
+ "esp-radio-rtos-driver",
+ "esp-sync",
+ "portable-atomic",
+]
+
+[[package]]
+name = "esp-storage"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1495fc1f5549bdd840b52d9ceb201746200e1620d2636f46958c11e765623b80"
+dependencies = [
+ "defmt 1.0.1",
  "document-features",
  "embedded-storage",
+ "esp-hal",
+ "esp-hal-procmacros",
+ "esp-metadata-generated",
  "esp-rom-sys",
+ "esp-sync",
+]
+
+[[package]]
+name = "esp-sync"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d44974639b4e88914f83fe60d2832c00276657d7d857628fdfc966cc7302e8a8"
+dependencies = [
+ "cfg-if",
+ "defmt 1.0.1",
+ "document-features",
+ "embassy-sync 0.6.2",
+ "embassy-sync 0.7.2",
+ "esp-metadata-generated",
+ "riscv",
+ "xtensa-lx",
 ]
 
 [[package]]
@@ -1367,50 +1446,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "esp-wifi"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84908f2e95cb99a200cf448abafc416576338be590778a15d9224eee237f3210"
-dependencies = [
- "allocator-api2",
- "bt-hci",
- "cfg-if",
- "critical-section",
- "defmt 1.0.1",
- "document-features",
- "embassy-net-driver",
- "embedded-io 0.6.1",
- "embedded-io-async 0.6.1",
- "enumset",
- "esp-alloc",
- "esp-config",
- "esp-hal",
- "esp-metadata-generated",
- "esp-wifi-sys",
- "num-derive",
- "num-traits",
- "portable-atomic",
- "portable_atomic_enum",
- "rand_core 0.9.3",
- "smoltcp",
- "xtensa-lx-rt",
-]
-
-[[package]]
 name = "esp-wifi-sys"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b5438361891c431970194a733415006fb3d00b6eb70b3dcb66fd58f04d9b39"
+checksum = "89b6544f6f0cb86169d1f93ba2101a8d50358a040c5043676ed86b793e09b12c"
 dependencies = [
  "anyhow",
- "defmt 0.3.100",
+ "defmt 1.0.1",
 ]
 
 [[package]]
 name = "esp32"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7680f79e3a4770e59c2dc25b17dcd852921ee57ffae9a4c4806c9ca5001d54d"
+checksum = "b76170a463d18f888a1ad258031901036fd827a9ef126733053ba5f8739fb0c8"
 dependencies = [
  "critical-section",
  "defmt 1.0.1",
@@ -1419,9 +1468,9 @@ dependencies = [
 
 [[package]]
 name = "esp32c2"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da1bcf86fca83543e0e95561cba27bbcc6b6e7adc5428f49187f5868bc0c3ed2"
+checksum = "e62cf8932966b8d445b6f1832977b468178f0a84effb2e9fda89f60c24d45aa3"
 dependencies = [
  "critical-section",
  "defmt 1.0.1",
@@ -1430,9 +1479,9 @@ dependencies = [
 
 [[package]]
 name = "esp32c3"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2c5a33d4377f974cbe8cadf8307f04f2c39755704cb09e81852c63ee4ac7b8"
+checksum = "356af3771d0d6536c735bf71136594f4d1cbb506abf6e0c51a6639e9bf4e7988"
 dependencies = [
  "critical-section",
  "defmt 1.0.1",
@@ -1441,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "esp32c6"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca8fc81b7164df58b5e04aaac9e987459312e51903cca807317990293973a6e"
+checksum = "8f5e511df672d79cd63365c92045135e01ba952b6bddd25b660baff5e1110f6b"
 dependencies = [
  "critical-section",
  "defmt 1.0.1",
@@ -1452,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "esp32h2"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80171d08c17d8c63b53334c60ca654786a7593481531d19b639c4e5c76d276de"
+checksum = "ed4a50bbd1380931e095e0973b9b12f782a9c481f2edf1f7c42e7eb4ff736d6d"
 dependencies = [
  "critical-section",
  "defmt 1.0.1",
@@ -1463,9 +1512,9 @@ dependencies = [
 
 [[package]]
 name = "esp32s2"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c90d347480fca91f4be3e94b576af9c6c7987795c58dc3c5a7c108b6b3966dc"
+checksum = "98574d4c577fbe888fe3e6df7fc80d25a05624d9998f7d7de1500ae21fcca78f"
 dependencies = [
  "critical-section",
  "defmt 1.0.1",
@@ -1474,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "esp32s3"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3769c56222c4548833f236c7009f1f8b3f2387af26366f6bd1cea456666a49d"
+checksum = "1810d8ee4845ef87542af981e38eb80ab531d0ef1061e1486014ab7af74c337a"
 dependencies = [
  "critical-section",
  "defmt 1.0.1",
@@ -1484,18 +1533,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "evalexpr"
-version = "12.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a3229bec56a977f174b32fe7b8d89e8c79ebb4493d10ad763b6676dc2dc0c9"
-
-[[package]]
 name = "faster-hex"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
 dependencies = [
- "heapless",
+ "heapless 0.8.0",
 ]
 
 [[package]]
@@ -1718,9 +1761,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heapless"
@@ -1730,7 +1773,18 @@ checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
  "defmt 0.3.100",
  "hash32",
- "serde",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
+dependencies = [
+ "defmt 1.0.1",
+ "hash32",
+ "serde_core",
  "stable_deref_trait",
 ]
 
@@ -1754,13 +1808,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown",
- "serde",
 ]
 
 [[package]]
@@ -1822,6 +1875,30 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49cce2b81f2098e7e3efc35bc2e0a6b7abec9d34128283d7a26fa8f32a6dbb35"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "js-sys"
@@ -1897,9 +1974,6 @@ name = "litrs"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
-dependencies = [
- "proc-macro2",
-]
 
 [[package]]
 name = "lock_api"
@@ -2075,6 +2149,15 @@ name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -2256,6 +2339,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "portable_atomic_enum"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,9 +2387,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
 ]
@@ -2384,12 +2476,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "r0"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7a31eed1591dcbc95d92ad7161908e72f4677f8fabf2a32ca49b4237cbf211"
-
-[[package]]
 name = "ral-registers"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,9 +2551,9 @@ dependencies = [
 
 [[package]]
 name = "riscv"
-version = "0.12.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea8ff73d3720bdd0a97925f0bf79ad2744b6da8ff36be3840c48ac81191d7a7"
+checksum = "b05cfa3f7b30c84536a9025150d44d26b8e1cc20ddf436448d74cd9591eefb25"
 dependencies = [
  "critical-section",
  "embedded-hal 1.0.0",
@@ -2478,9 +2564,9 @@ dependencies = [
 
 [[package]]
 name = "riscv-macros"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f265be5d634272320a7de94cea15c22a3bfdd4eb42eb43edc528415f066a1f25"
+checksum = "7d323d13972c1b104aa036bc692cd08b822c8bbf23d79a27c526095856499799"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2494,15 +2580,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8188909339ccc0c68cfb5a04648313f09621e8b87dc03095454f1a11f6c5d436"
 
 [[package]]
-name = "riscv-rt-macros"
-version = "0.4.0"
+name = "riscv-rt"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc71814687c45ba4cd1e47a54e03a2dbc62ca3667098fbae9cc6b423956758fa"
+checksum = "3d07b9f3a0eff773fc4df11f44ada4fa302e529bff4b7fe7e6a4b98a65ce9174"
+dependencies = [
+ "defmt 1.0.1",
+ "riscv",
+ "riscv-pac",
+ "riscv-rt-macros",
+ "riscv-target-parser",
+]
+
+[[package]]
+name = "riscv-rt-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c3138fdd8d128b2d81829842a3e0ce771b3712f7b6318ed1476b0695e7d330"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
 ]
+
+[[package]]
+name = "riscv-target-parser"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1376b15f3ff160e9b1e8ea564ce427f2f6fcf77528cc0a8bf405cb476f9cea7"
 
 [[package]]
 name = "rlsf"
@@ -2623,18 +2728,28 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2643,14 +2758,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2737,9 +2853,24 @@ dependencies = [
  "byteorder",
  "cfg-if",
  "defmt 0.3.100",
- "heapless",
+ "heapless 0.8.0",
  "managed",
 ]
+
+[[package]]
+name = "somni-expr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed9b7648d5e8b2df6c5e49940c54bcdd2b4dd71eafc6e8f1c714eb4581b0f53"
+dependencies = [
+ "somni-parser",
+]
+
+[[package]]
+name = "somni-parser"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0f368519fc6c85fc1afdb769fb5a51123f6158013e143656e25a3485a0d401c"
 
 [[package]]
 name = "ssd1306"
@@ -2925,9 +3056,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "36cde6a64bcbb101731e7db34c087674206357a5316e6f695f5fef730bd711de"
 dependencies = [
  "backtrace",
  "io-uring",
@@ -2951,19 +3082,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.23.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "5d7cbc3b4b49633d57a0509303158ca50de80ae32c265093b24c414705807832"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow 0.7.12",
+ "toml_parser",
+ "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+dependencies = [
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -3062,7 +3206,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
 dependencies = [
- "heapless",
+ "heapless 0.8.0",
  "portable-atomic",
 ]
 
@@ -3102,6 +3246,7 @@ dependencies = [
  "console_error_panic_hook",
  "const_format",
  "cortex-m-rt",
+ "critical-section",
  "defmt-rtt",
  "delegate",
  "display-interface",
@@ -3110,8 +3255,8 @@ dependencies = [
  "embassy-futures",
  "embassy-net",
  "embassy-rp",
- "embassy-sync 0.7.0",
- "embassy-time",
+ "embassy-sync 0.7.2",
+ "embassy-time 0.5.0",
  "embedded-alloc",
  "embedded-graphics",
  "embedded-hal 1.0.0",
@@ -3122,14 +3267,15 @@ dependencies = [
  "embedded-text",
  "esp-alloc",
  "esp-backtrace",
+ "esp-bootloader-esp-idf",
  "esp-hal",
- "esp-hal-embassy",
+ "esp-radio",
+ "esp-rtos",
  "esp-storage",
- "esp-wifi",
  "faster-hex",
  "fixed",
  "fixed-macro",
- "heapless",
+ "heapless 0.9.2",
  "httparse",
  "itoa",
  "loog",
@@ -3154,7 +3300,7 @@ dependencies = [
 name = "vertx-config-migrate"
 version = "0.0.0"
 dependencies = [
- "heapless",
+ "heapless 0.9.2",
  "postcard",
  "serde",
 ]
@@ -3163,9 +3309,9 @@ dependencies = [
 name = "vertx-crsf"
 version = "0.0.0"
 dependencies = [
- "bitfield 0.19.1",
+ "bitfield 0.19.4",
  "crc",
- "embedded-io 0.6.1",
+ "embedded-io 0.7.1",
 ]
 
 [[package]]
@@ -3173,7 +3319,7 @@ name = "vertx-filesystem"
 version = "0.0.0"
 dependencies = [
  "aligned",
- "bitfield 0.19.1",
+ "bitfield 0.19.4",
  "block-device-driver",
  "bytemuck",
  "crc",
@@ -3503,39 +3649,39 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "xtensa-lx"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a564fffeb3cd773a524e8d8a5c66ca5e9739ea7450e36a3e6a54dd31f1e652f"
+checksum = "e012d667b0aa6d2592ace8ef145a98bff3e76cca7a644f4181ecd7a916ed289b"
 dependencies = [
  "critical-section",
 ]
 
 [[package]]
 name = "xtensa-lx-rt"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520a8fb0121eb6868f4f5ff383e262dc863f9042496724e01673a98a9b7e6c2b"
+checksum = "8709f037fb123fe7ff146d2bce86f9dc0dfc53045c016bfd9d703317b6502845"
 dependencies = [
+ "defmt 1.0.1",
  "document-features",
- "r0",
  "xtensa-lx",
  "xtensa-lx-rt-proc-macros",
 ]
 
 [[package]]
 name = "xtensa-lx-rt-proc-macros"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a56a616147f5947ceb673790dd618d77b30e26e677f4a896df049d73059438"
+checksum = "96fb42cd29c42f8744c74276e9f5bee7b06685bbe5b88df891516d72cb320450"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ license = "MPL-2.0"
 
 [workspace.dependencies]
 aligned = "=0.4.2"
-bitfield = "=0.19.1"
+bitfield = "=0.19.4"
 block-device-driver = "=0.2.0"
-bytemuck = { version = "=1.23.1", features = ["const_zeroed", "min_const_generics", "must_cast"] }
-crc = "=3.3.0"
+bytemuck = { version = "=1.24.0", features = ["const_zeroed", "min_const_generics", "must_cast"] }
+crc = "=3.4.0"
 embedded-io-async = "=0.6.1"
-heapless = "=0.8.0"
+heapless = "=0.9.2"
 loog = { git = "https://github.com/wetheredge/loog.git", rev = "4785bb8f607191354e7d3d9df8790fe998392cbc" }
 postcard = { version = "=1.1.3", default-features = false }
-serde = { version = "=1.0.219", default-features = false }
-tokio = "=1.47.1"
+serde = { version = "=1.0.228", default-features = false }
+tokio = "=1.47.2"
 vertx-filesystem = { path = "./vertx-filesystem" }
 
 [workspace.lints.rust]
@@ -91,7 +91,7 @@ opt-level = 1
 [profile.dev.package.esp-storage]
 opt-level = 3
 
-[profile.dev.package.esp-wifi]
+[profile.dev.package.esp-radio]
 opt-level = 3
 
 [profile.release]

--- a/vertx-crsf/Cargo.toml
+++ b/vertx-crsf/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 bitfield = { workspace = true }
 crc = { workspace = true }
-embedded-io = "=0.6.1"
+embedded-io = "=0.7.1"
 
 [lints]
 workspace = true

--- a/vertx-filesystem/src/error.rs
+++ b/vertx-filesystem/src/error.rs
@@ -1,0 +1,76 @@
+use core::error::Error as CoreError;
+use core::fmt;
+
+use block_device_driver::BlockDevice;
+use embedded_io_async as eio;
+#[cfg(feature = "defmt")]
+use loog::defmt;
+
+use crate::BLOCK_BYTES;
+
+#[derive(Debug, Clone, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum Error<I> {
+    SeekOutOfBounds,
+    /// The operation would require allocating more backing blocks for the
+    /// file, which is (yet) supported.
+    FileFull,
+    TooManyModels,
+    ModelNameOverflow,
+    Io(I),
+}
+
+impl<I: fmt::Display> fmt::Display for Error<I> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SeekOutOfBounds => f.write_str("seek out of bounds"),
+            Self::FileFull => f.write_str("file is full and cannot be reallocated"),
+            Self::TooManyModels => f.write_str("no model ids left"),
+            Self::ModelNameOverflow => f.write_str("model name is too long"),
+            Self::Io(io) => fmt::Display::fmt(io, f),
+        }
+    }
+}
+
+impl<I: CoreError> CoreError for Error<I> {}
+
+#[allow(clippy::match_same_arms)]
+impl<I: eio::Error> eio::Error for Error<I> {
+    fn kind(&self) -> eio::ErrorKind {
+        match self {
+            Self::SeekOutOfBounds => eio::ErrorKind::InvalidInput,
+            Self::FileFull => eio::ErrorKind::Unsupported,
+            Self::TooManyModels => eio::ErrorKind::InvalidData,
+            Self::ModelNameOverflow => eio::ErrorKind::InvalidInput,
+            Self::Io(err) => err.kind(),
+        }
+    }
+}
+
+impl<I> From<I> for Error<I> {
+    fn from(io: I) -> Self {
+        Self::Io(io)
+    }
+}
+
+pub enum InitError<'buf, D: BlockDevice<BLOCK_BYTES>> {
+    HeaderError {
+        kind: crate::HeaderError,
+        device: D,
+        buffers: &'buf mut crate::Buffers<D::Align>,
+    },
+    Io(D::Error),
+}
+
+impl<D: BlockDevice<BLOCK_BYTES>> fmt::Debug for InitError<'_, D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::HeaderError { kind, .. } => f
+                .debug_struct("HeaderError")
+                .field("kind", kind)
+                .finish_non_exhaustive(),
+            Self::Io(io) => f.debug_tuple("Io").field(io).finish(),
+        }
+    }
+}

--- a/vertx/Cargo.toml
+++ b/vertx/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 publish = false
 
 [package.metadata.cargo-shear]
-ignored = ["cortex-m-rt"]
+ignored = ["critical-section", "cortex-m-rt"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -60,18 +60,21 @@ chip-esp = [
     "storage-sd-spi",
     "dep:esp-alloc",
     "dep:esp-backtrace",
+    "dep:esp-bootloader-esp-idf",
     "dep:esp-hal",
-    "dep:esp-hal-embassy",
+    "dep:esp-rtos",
     "dep:esp-storage",
-    "dep:esp-wifi",
+    "dep:esp-radio",
 ]
 chip-esp32s3 = [
     "chip-esp",
+    "esp-alloc/esp32s3",
     "esp-backtrace/esp32s3",
+    "esp-bootloader-esp-idf/esp32s3",
     "esp-hal/esp32s3",
-    "esp-hal-embassy/esp32s3",
+    "esp-rtos/esp32s3",
     "esp-storage/esp32s3",
-    "esp-wifi/esp32s3",
+    "esp-radio/esp32s3",
 ]
 
 chip-rp = [
@@ -112,21 +115,21 @@ simulator = [
 [dependencies]
 aligned = { workspace = true }
 bytemuck = { workspace = true }
-const_format = "=0.2.34"
-defmt-rtt = "=1.0.0"
-delegate = "=0.13.4"
+const_format = "=0.2.35"
+defmt-rtt = "=1.1.0"
+delegate = "=0.13.5"
 display-interface = "=0.5.0"
-embassy-executor = { version = "=0.7.0", features = ["nightly"] }
-embassy-futures = "=0.1.1"
-embassy-sync = "=0.7.0"
-embassy-time = { version = "=0.4.0", features = ["generic-queue-8"] }
+embassy-executor = { version = "=0.9.1", features = ["nightly"] }
+embassy-futures = "=0.1.2"
+embassy-sync = "=0.7.2"
+embassy-time = { version = "=0.5.0", features = ["generic-queue-8"] }
 embedded-graphics = "=0.8.1"
 embedded-hal = "=1.0.0"
 embedded-hal-async = "=1.0.0"
 embedded-hal-bus = { version = "=0.3.0", features = ["async"] }
 embedded-io-async = { workspace = true, features = ["defmt-03"] }
 embedded-mogeefont = "=0.1.0"
-embedded-text = "=0.7.2"
+embedded-text = "=0.7.3"
 heapless = { workspace = true, features = ["serde"] }
 loog = { workspace = true }
 portable-atomic = { version = "=1.11.1", features = ["critical-section"] }
@@ -144,7 +147,7 @@ ssd1306 = { version = "=0.10.0", features = ["async"], optional = true }
 
 # network
 edge-dhcp = { version = "=0.6.0", optional = true }
-embassy-net = { version = "=0.7.0", features = ["dhcpv4", "dhcpv4-hostname", "tcp", "udp"], optional = true }
+embassy-net = { version = "=0.7.1", features = ["dhcpv4", "dhcpv4-hostname", "tcp", "udp"], optional = true }
 faster-hex = { version = "=0.10.0", default-features = false, optional = true }
 httparse = { version = "=1.10.1", default-features = false, optional = true }
 
@@ -154,17 +157,18 @@ sdspi = { git = "https://github.com/wetheredge/embedded-fatfs.git", rev = "37a38
 vertx-filesystem = { workspace = true, optional = true }
 
 # chip-esp
-esp-alloc = { version = "=0.8.0", optional = true }
-esp-backtrace = { version = "=0.17.0", features = ["defmt", "colors", "panic-handler", "exception-handler"], optional = true }
-esp-hal = { version = "=1.0.0-rc.0", features = ["unstable"], optional = true }
-esp-hal-embassy = { version = "=0.9.0", default-features = false, features = ["executors"], optional = true }
-esp-storage = { version = "=0.7.0", features = ["critical-section"], optional = true }
-esp-wifi = { version = "=0.15.0", features = ["defmt", "wifi"], optional = true }
+esp-alloc = { version = "=0.9.0", features = ["defmt"], optional = true }
+esp-backtrace = { version = "=0.18.1", features = ["defmt", "colors", "panic-handler"], optional = true }
+esp-bootloader-esp-idf = { version = "=0.4.0", features = ["defmt"], optional = true }
+esp-hal = { version = "=1.0.0", features = ["unstable"], optional = true }
+esp-radio = { version = "=0.17.0", features = ["defmt", "wifi"], optional = true }
+esp-rtos = { version = "0.2.0", features = ["defmt", "embassy", "esp-radio"], optional = true }
+esp-storage = { version = "=0.8.1", features = ["defmt", "critical-section"], optional = true }
 
 # chip-rp
 # TODO: flip-link
 cortex-m-rt = { version = "=0.7.5", optional = true }
-embassy-rp = { version = "=0.6.0", features = ["defmt", "critical-section-impl", "time-driver"], optional = true }
+embassy-rp = { version = "=0.9.0", features = ["defmt", "critical-section-impl", "time-driver"], optional = true }
 embedded-alloc = { version = "=0.6.0", optional = true }
 fixed = { version = "=1.29.0", optional = true }
 fixed-macro = { version = "=1.2.0", optional = true }
@@ -173,6 +177,7 @@ pio = { version = "=0.3.0", optional = true }
 
 [target.wasm32-unknown-unknown.dependencies]
 console_error_panic_hook = "=0.1.7"
+critical-section = { version = "=1.2.0", features = ["std"] }
 talc = "=4.4.3"
 wasm-bindgen = "=0.2.105"
 wasm-logger = "=0.2.0"
@@ -180,7 +185,7 @@ wasm-logger = "=0.2.0"
 [build-dependencies]
 basic-toml = "=0.1.10"
 serde = { workspace = true, features = ["derive"] }
-serde_json = "=1.0.142"
+serde_json = "=1.0.145"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "test-util"] }

--- a/vertx/src/hal/chip/esp/leds.rs
+++ b/vertx/src/hal/chip/esp/leds.rs
@@ -6,8 +6,7 @@ use core::slice::IterMut;
 
 use esp_hal::clock::Clocks;
 use esp_hal::gpio::{self, OutputPin};
-use esp_hal::rmt;
-use esp_hal::rmt::TxChannelAsync as _;
+use esp_hal::rmt::{self, PulseCode};
 
 const PERIOD: u32 = 1250; // 800kHz
 const T0H_NS: u32 = 400; // 300ns per SK6812 datasheet, 400 per WS2812. Some require >350ns for T0H. Others <500ns for T0H.
@@ -15,16 +14,15 @@ const T0L_NS: u32 = PERIOD - T0H_NS;
 const T1H_NS: u32 = 850; // 900ns per SK6812 datasheet, 850 per WS2812. > 550ns is sometimes enough. Some require T1H >= 2 * T0H. Some require > 300ns T1L.
 const T1L_NS: u32 = PERIOD - T1H_NS;
 
-pub(super) struct StatusLed {
-    channel: rmt::AnyTxChannel<esp_hal::Async>,
-    pulses: (u32, u32),
+pub(super) struct StatusLed<'d> {
+    channel: rmt::Channel<'d, esp_hal::Async, rmt::Tx>,
+    pulses: (PulseCode, PulseCode),
 }
 
-impl StatusLed {
-    pub(super) fn new<'d, C, R>(channel: C, pin: impl OutputPin + 'd) -> Self
+impl<'d> StatusLed<'d> {
+    pub(super) fn new<C>(channel: C, pin: impl OutputPin + 'd) -> Self
     where
-        C: rmt::TxChannelCreator<'d, esp_hal::Async, Raw = R>,
-        R: rmt::RawChannelAccess<Dir = rmt::Tx>,
+        C: rmt::TxChannelCreator<'d, esp_hal::Async>,
     {
         let config = rmt::TxChannelConfig::default()
             .with_clk_divider(1)
@@ -39,15 +37,15 @@ impl StatusLed {
         let src_clock = clocks.apb_clock.as_mhz();
 
         Self {
-            channel: channel.degrade(),
+            channel,
             pulses: (
-                rmt::PulseCode::new(
+                PulseCode::new(
                     gpio::Level::High,
                     ((T0H_NS * src_clock) / 1000) as u16,
                     gpio::Level::Low,
                     ((T0L_NS * src_clock) / 1000) as u16,
                 ),
-                rmt::PulseCode::new(
+                PulseCode::new(
                     gpio::Level::High,
                     ((T1H_NS * src_clock) / 1000) as u16,
                     gpio::Level::Low,
@@ -58,12 +56,12 @@ impl StatusLed {
     }
 }
 
-impl crate::hal::traits::StatusLed for StatusLed {
+impl crate::hal::traits::StatusLed for StatusLed<'_> {
     type Error = rmt::Error;
 
     async fn set(&mut self, red: u8, green: u8, blue: u8) -> Result<(), Self::Error> {
         // 3 channels * 8 bits/pulses + stop
-        let mut buffer = [rmt::PulseCode::empty(); 25];
+        let mut buffer = [PulseCode::end_marker(); 25];
 
         let buffer_iter = &mut buffer.iter_mut();
         push_pulses(green, buffer_iter, self.pulses);
@@ -74,7 +72,7 @@ impl crate::hal::traits::StatusLed for StatusLed {
     }
 }
 
-fn push_pulses(value: u8, out: &mut IterMut<u32>, pulses: (u32, u32)) {
+fn push_pulses(value: u8, out: &mut IterMut<PulseCode>, pulses: (PulseCode, PulseCode)) {
     for position in [128, 64, 32, 16, 8, 4, 2, 1] {
         *out.next().unwrap() = match value & position {
             0 => pulses.0,

--- a/vertx/src/hal/chip/esp/mod.rs
+++ b/vertx/src/hal/chip/esp/mod.rs
@@ -30,7 +30,9 @@ esp_bootloader_esp_idf::esp_app_desc!();
     hal::Ui
 )]
 pub(crate) fn init(spawner: Spawner) -> hal::Init {
-    esp_alloc::heap_allocator!(size: 100 * 1024);
+    #[cfg(feature = "chip-esp32s3")]
+    const HEAP_SIZE: usize = 73744;
+    esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: HEAP_SIZE);
 
     let p = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
 

--- a/vertx/src/hal/chip/esp/mod.rs
+++ b/vertx/src/hal/chip/esp/mod.rs
@@ -19,6 +19,8 @@ use {defmt_rtt as _, esp_backtrace as _};
 
 use crate::hal;
 
+esp_bootloader_esp_idf::esp_app_desc!();
+
 #[define_opaque(
     hal::Network,
     hal::Reset,
@@ -33,16 +35,14 @@ pub(crate) fn init(spawner: Spawner) -> hal::Init {
     let p = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
 
     let rmt = Rmt::new(p.RMT, Rate::from_mhz(80)).unwrap().into_async();
-    let rng = Rng::new(p.RNG);
+    let rng = Rng::new();
     let timg0 = timg::TimerGroup::new(p.TIMG0);
-    let timg1 = timg::TimerGroup::new(p.TIMG1);
 
-    esp_hal_embassy::init(timg0.timer0);
+    esp_rtos::start(timg0.timer0);
 
     let status_led = leds::StatusLed::new(rmt.channel0, pins!(p, leds.status));
 
     let spi = {
-        #[expect(clippy::manual_div_ceil)]
         let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = esp_hal::dma_buffers!(32000);
         let dma_rx = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
         let dma_tx = DmaTxBuf::new(tx_descriptors, tx_buffer).unwrap();
@@ -104,7 +104,6 @@ pub(crate) fn init(spawner: Spawner) -> hal::Init {
         network: network::Network {
             spawner,
             rng,
-            timer: timg1.timer0.into(),
             wifi: p.WIFI,
         },
     }

--- a/vertx/src/main.rs
+++ b/vertx/src/main.rs
@@ -3,7 +3,7 @@
 #![feature(impl_trait_in_assoc_type)]
 #![feature(type_alias_impl_trait)]
 
-#[cfg_attr(feature = "chip-esp", esp_hal_embassy::main)]
+#[cfg_attr(feature = "chip-esp", esp_rtos::main)]
 #[cfg_attr(feature = "chip-rp", embassy_executor::main)]
 async fn main(spawner: embassy_executor::Spawner) {
     vertx::main(spawner).await;

--- a/vertx/src/network/mod.rs
+++ b/vertx/src/network/mod.rs
@@ -73,7 +73,7 @@ pub(crate) async fn init(
         Kind::AccessPoint => embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
             address: embassy_net::Ipv4Cidr::new(STATIC_ADDRESS, 24),
             gateway: Some(STATIC_ADDRESS),
-            dns_servers: heapless::Vec::new(),
+            dns_servers: Default::default(),
         }),
     };
 


### PR DESCRIPTION
|    | Name | Old | New | Manager | Path | Kind |
|:---|:-----|:----|:----|:--------|:-----|:-----|
|    | `aligned` | =0.4.2 |  | Cargo | `/vertx` | Runtime |
|    | `atoi` | =2.0.0 |  | Cargo | `/vertx` | Runtime |
|    | `basic-toml` | =0.1.10 |  | Cargo | `/vertx` | Build |
| ✔️ | `bitfield` | =0.19.1 | =0.19.4 | Cargo | `/vertx-crsf` | Runtime |
| ✔️ | `bytemuck` | =1.23.1 | =1.24.0 | Cargo | `/vertx` | Runtime |
|    | `console_error_panic_hook` | =0.1.7 |  | Cargo | `/vertx` | Runtime (wasm32-unknown-unknown) |
| ✔️ | `const_format` | =0.2.34 | =0.2.35 | Cargo | `/vertx` | Runtime |
|    | `cortex-m-rt` | =0.7.5 |  | Cargo | `/vertx` | Runtime |
| ✔️ | `crc` | =3.3.0 | =3.4.0 | Cargo | `/vertx-crsf` | Runtime |
| ✔️ | `defmt-rtt` | =1.0.0 | =1.1.0 | Cargo | `/vertx` | Runtime |
| ✔️ | `delegate` | =0.13.4 | =0.13.5 | Cargo | `/vertx` | Runtime |
|    | `display-interface` | =0.5.0 |  | Cargo | `/vertx` | Runtime |
|    | `edge-dhcp` | =0.6.0 |  | Cargo | `/vertx` | Runtime |
| ✔️ | `embassy-executor` | =0.7.0 | =0.9.1 | Cargo | `/vertx` | Runtime |
| ✔️ | `embassy-futures` | =0.1.1 | =0.1.2 | Cargo | `/vertx` | Runtime |
| ✔️ | `embassy-net` | =0.7.0 | =0.7.1 | Cargo | `/vertx` | Runtime |
| ✔️ | `embassy-rp` | =0.6.0 | =0.9.0 | Cargo | `/vertx` | Runtime |
| ✔️ | `embassy-sync` | =0.7.0 | =0.7.2 | Cargo | `/vertx` | Runtime |
| ✔️ | `embassy-time` | =0.4.0 | =0.5.0 | Cargo | `/vertx` | Runtime |
|    | `embedded-alloc` | =0.6.0 |  | Cargo | `/vertx` | Runtime |
|    | `embedded-graphics` | =0.8.1 |  | Cargo | `/vertx` | Runtime |
|    | `embedded-hal` | =1.0.0 |  | Cargo | `/vertx` | Runtime |
|    | `embedded-hal-async` | =1.0.0 |  | Cargo | `/vertx` | Runtime |
|    | `embedded-hal-bus` | =0.3.0 |  | Cargo | `/vertx` | Runtime |
| ✔️ | `embedded-io` | =0.6.1 | =0.7.1 | Cargo | `/vertx-crsf` | Runtime |
| ❌ | `embedded-io-async` | =0.6.1 | =0.7.0 | Cargo | `/vertx` | Runtime |
|    | `embedded-mogeefont` | =0.1.0 |  | Cargo | `/vertx` | Runtime |
| ✔️ | `embedded-text` | =0.7.2 | =0.7.3 | Cargo | `/vertx` | Runtime |
| ✔️ | `esp-alloc` | =0.8.0 | =0.9.0 | Cargo | `/vertx` | Runtime |
| ✔️ | `esp-backtrace` | =0.17.0 | =0.18.1 | Cargo | `/vertx` | Runtime |
| ✔️ | `esp-hal` | =1.0.0-rc.0 | =1.0.0 | Cargo | `/vertx` | Runtime |
| ❌ | `esp-hal-embassy` | =0.9.0 | =0.9.1 | Cargo | `/vertx` | Runtime |
| ✔️ | `esp-storage` | =0.7.0 | =0.8.1 | Cargo | `/vertx` | Runtime |
| ❌ | `esp-wifi` | =0.15.0 | =0.15.1 | Cargo | `/vertx` | Runtime |
|    | `faster-hex` | =0.10.0 |  | Cargo | `/vertx` | Runtime |
|    | `fixed` | =1.29.0 |  | Cargo | `/vertx` | Runtime |
|    | `fixed-macro` | =1.2.0 |  | Cargo | `/vertx` | Runtime |
| ✔️ | `heapless` | =0.8.0 | =0.9.2 | Cargo | `/` | Workspace |
|    | `httparse` | =1.10.1 |  | Cargo | `/vertx` | Runtime |
|    | `itoa` | =1.0.15 |  | Cargo | `/vertx` | Runtime |
|    | `panic-probe` | =1.0.0 |  | Cargo | `/vertx` | Runtime |
|    | `pio` | =0.3.0 |  | Cargo | `/vertx` | Runtime |
|    | `portable-atomic` | =1.11.1 |  | Cargo | `/vertx` | Runtime |
|    | `postcard` | =1.1.3 |  | Cargo | `/` | Workspace |
|    | `qrcodegen-no-heap` | =1.8.1 |  | Cargo | `/vertx` | Runtime |
| ✔️ | `serde` | =1.0.219 | =1.0.228 | Cargo | `/` | Workspace |
| ✔️ | `serde_json` | =1.0.142 | =1.0.145 | Cargo | `/vertx` | Build |
|    | `ssd1306` | =0.10.0 |  | Cargo | `/vertx` | Runtime |
|    | `static_cell` | =2.1.1 |  | Cargo | `/vertx` | Runtime |
|    | `talc` | =4.4.3 |  | Cargo | `/vertx` | Runtime (wasm32-unknown-unknown) |
| ✔️ | `tokio` | =1.47.1 | =1.47.2 | Cargo | `/vertx` | Dev |
| ✔️ | `wasm-bindgen` | =0.2.100 | =0.2.105 | Cargo | `/vertx` | Runtime (wasm32-unknown-unknown) |
|    | `wasm-logger` | =0.2.0 |  | Cargo | `/vertx` | Runtime (wasm32-unknown-unknown) |

Replaced:
- `esp-hal-embassy` -> `esp-rtos`
- `esp-wifi` -> `esp-radio`